### PR TITLE
fix:bug

### DIFF
--- a/index.es
+++ b/index.es
@@ -42,6 +42,13 @@ let handleGameResponse = (e) => {
                 eKyouka = body.api_eKyouka;
             if (typeof body.api_dock_id !== "undefined" && body.api_dock_id !== null)
                 dock_id = body.api_dock_id;
+            /*
+            在20171117更新中，至少
+            '/kcsapi/api_req_sortie/battle'
+            的api中的api_dock_id修改了拼写，变为api_deck_id，导致dock_id没有被正确赋值
+            */
+            if (typeof body.api_deck_id !== "undefined" && body.api_deck_id !== null)
+                dock_id = body.api_deck_id;
             reportEnemy(body);
             break;
         case '/kcsapi/api_get_member/ship_deck':


### PR DESCRIPTION
 在20171117更新中，至少
'/kcsapi/api_req_sortie/battle'
的[api中的api_dock_id](https://github.com/andanteyk/ElectronicObserver/blob/e063de1aeba92f7d24e6066965bb790a9e4d3519/ElectronicObserver/Other/Information/apilist.txt#L1519)修改了拼写，变为[api_deck_id](https://github.com/andanteyk/ElectronicObserver/blob/58571bf5dd0ac6a61132414c5cd2fd6261a3d6bf/ElectronicObserver/Other/Information/apilist.txt#L1524)，导致dock_id没有被正确赋值